### PR TITLE
Add 429 handling, HTTP timeouts, and per-record exception isolation

### DIFF
--- a/doab_check/check.py
+++ b/doab_check/check.py
@@ -30,27 +30,29 @@ class ContentTyper(object):
     def content_type(self, url):
         try:
             try:
-                r = requests.get(url, allow_redirects=True, headers=HEADERS)
+                r = requests.get(url, allow_redirects=True, headers=HEADERS, timeout=(5, 60))
             except UnicodeDecodeError as ude:
                 # fallback for non-ascii, non-utf8 bytes in redirect location
                 if 'utf-8' in str(ude):
                     (scheme, netloc, path, query, fragment) = urlsplit(url)
                     newpath = quote(unquote(path), encoding='latin1')
                     url = urlunsplit((scheme, netloc, newpath, query, fragment))
-                    r = requests.get(url, allow_redirects=True, headers=HEADERS)
+                    r = requests.get(url, allow_redirects=True, headers=HEADERS, timeout=(5, 60))
                     if r.status_code == 200:
                         r.status_code = 214 # unofficial status code where url is changed
             if r.status_code == 405:
-                r =  requests.get(url, headers=HEADERS)
+                r =  requests.get(url, headers=HEADERS, timeout=(5, 60))
             return r
         except requests.exceptions.SSLError:
-            r = requests.get(url, verify=False)
+            r = requests.get(url, verify=False, timeout=(5, 60))
             r.status_code = 511
             return r
+        except requests.exceptions.Timeout:
+            return (524, '', '')
         except requests.exceptions.ConnectionError as ce:
             if '[Errno 8]' in str(ce) or '[Errno -2]' in str(ce):
                 try:
-                    r = requests.get(url, allow_redirects=False, headers=HEADERS)
+                    r = requests.get(url, allow_redirects=False, headers=HEADERS, timeout=(5, 60))
                     return r
                 except Exception as e:
                     pass

--- a/doab_check/check.py
+++ b/doab_check/check.py
@@ -44,9 +44,14 @@ class ContentTyper(object):
                 r =  requests.get(url, headers=HEADERS, timeout=(5, 60))
             return r
         except requests.exceptions.SSLError:
-            r = requests.get(url, verify=False, timeout=(5, 60))
-            r.status_code = 511
-            return r
+            try:
+                r = requests.get(url, verify=False, timeout=(5, 60))
+                r.status_code = 511
+                return r
+            except requests.exceptions.Timeout:
+                return (524, '', '')
+            except Exception:
+                return (511, '', '')
         except requests.exceptions.Timeout:
             return (524, '', '')
         except requests.exceptions.ConnectionError as ce:

--- a/doab_check/doab_oai.py
+++ b/doab_check/doab_oai.py
@@ -4,6 +4,7 @@
 import datetime
 import logging
 import re
+import urllib.error
 
 import pytz
 from dateutil.parser import isoparse
@@ -152,7 +153,11 @@ def load_doab_oai(from_date, until_date, limit=100):
             doab = getdoab(ident)
             if doab:
                 num_doabs += 1
-                item = add_by_doab(doab, record=record)
+                try:
+                    item = add_by_doab(doab, record=record)
+                except Exception as ex:
+                    logger.exception('unexpected error processing doab #%s: %s', doab, ex)
+                    continue
                 if not item:
                     logger.error('error for doab #%s', doab)
                     continue
@@ -160,8 +165,18 @@ def load_doab_oai(from_date, until_date, limit=100):
                     new_doabs += 1
                 title = item.title
                 logger.info(u'updated:\t%s\t%s', doab, title)
-            if num_doabs >= limit:
+            if limit is not None and num_doabs >= limit:
                 break
     except NoRecordsMatchError:
         pass
+    except urllib.error.HTTPError as e:
+        if e.code == 429:
+            retry_after = e.headers.get('Retry-After', 'unknown')
+            logger.error(
+                'DOAB OAI rate-limited (HTTP 429). '
+                'Retry-After: %s seconds. Harvest stopped after %s records.',
+                retry_after, num_doabs
+            )
+        else:
+            raise
     return num_doabs, new_doabs, lasttime

--- a/doab_check/doab_utils.py
+++ b/doab_check/doab_utils.py
@@ -58,7 +58,11 @@ STREAM_QUERY = 'https://directory.doabooks.org/rest/search?query=handle:{}&expan
 def get_streamdata(handle):
     url = STREAM_QUERY.format(handle)
     try:
-        response = requests.get(url, headers={"User-Agent": settings.USER_AGENT})
+        response = requests.get(url, headers={"User-Agent": settings.USER_AGENT}, timeout=(5, 60))
+        if response.status_code == 429:
+            retry_after = response.headers.get('Retry-After', 'unknown')
+            logger.error('DOAB bitstream API rate-limited (HTTP 429) for %s. Retry-After: %s', handle, retry_after)
+            return None
         items = response.json()
         if items:
             for stream in items[0]['bitstreams']:


### PR DESCRIPTION
## Summary

Ports the reliability fixes from Gluejar/regluit ([issue #1096](https://github.com/Gluejar/regluit/issues/1096), PRs #1097–#1108) to doab-check. Same root causes identified during the regluit DOAB harvester investigation.

### Changes

**doab_oai.py** — OAI harvest loop:
- `limit is not None` guard (Python 3 `TypeError` on `int >= None`)
- Per-record `try/except Exception` with `logger.exception()` — one bad record no longer kills the whole harvest
- `urllib.error.HTTPError` handler for 429 — logs `Retry-After` header and returns gracefully

**doab_utils.py** — bitstream API:
- `timeout=(5, 60)` on `requests.get()` in `get_streamdata()`
- 429 status check before calling `.json()` (429 returns HTML, causing misleading `ValueError`)

**check.py** — link checker / ContentTyper:
- `timeout=(5, 60)` on all 6 `requests.get()` calls
- `requests.exceptions.Timeout` handler returning `(524, '', '')` (consistent with existing timeout handling)

## Context

These are the same bugs that caused regluit's DOAB harvester to miss hundreds of books over several months. doab-check's codebase shares the same patterns and was vulnerable to the same failures.

Closes #2, closes #3, closes #4.