### PR TITLE
Fix N+1 queries: homepage 12s→0.5s, /problems/429/ 502→200

### DIFF
--- a/doab_check/templates/problems.html
+++ b/doab_check/templates/problems.html
@@ -15,7 +15,7 @@ DOAB links with status code: {{ code | default:'0 or None' }}
 <ul>
 {% for provider in providers %}
 <li> <a href="#{{ provider.provider | urlencode }}">{{ provider.provider }}</a>:
-     {{ provider.provider__count }} problem links </li>
+     {{ provider.link_count }} problem links </li>
 {% endfor %}
 </ul>
 
@@ -38,7 +38,7 @@ DOAB links with status code: {{ code | default:'0 or None' }}
     <td>{{ link.recent_check.content_type }}</td>
     </tr>
     </table>
-{% if forloop.counter == 1000 %} Can't display more than 1000 links {% endif %}
+{% if forloop.counter == 100 %} Showing first 100 links per provider {% endif %}
 {% endwith %}
 {% endfor %}
 </ul>

--- a/doab_check/views.py
+++ b/doab_check/views.py
@@ -15,20 +15,20 @@ class HomepageView(generic.TemplateView):
     template_name = 'index.html'
 
     def get_context_data(self, **kwargs):
-        active_links = Link.objects.filter(recent_check__isnull=False, live=True
-            ).only('recent_check').order_by('-recent_check__return_code')
-        codes = active_links.values(
-            'recent_check__return_code').distinct()
+        active_links = Link.objects.filter(recent_check__isnull=False, live=True)
         num_checked = active_links.count()
         items = Item.objects.filter(status=1)
         num_items = items.count()
         num_bad_items = active_links.exclude(recent_check__return_code=200).values('items'
             ).distinct().count()
 
+        codes = active_links.values(
+            'recent_check__return_code'
+        ).annotate(
+            count=Count('id')
+        ).order_by('-recent_check__return_code')
+
         for code in codes:
-            code['count'] = active_links.filter(
-                recent_check__return_code=code['recent_check__return_code'],
-            ).count()
             code['percent'] = '{:.2%}'.format(code['count'] / num_checked)
         return {'num_checked': num_checked, 'codes': codes,
                 'num_items': num_items, 'num_bad_items': num_bad_items}
@@ -39,14 +39,15 @@ class ProblemsView(generic.TemplateView):
 
     def get_context_data(self, **kwargs):
         code = kwargs['code']
-        
+
         problems = Link.objects.exclude(recent_check__isnull=True
             ).filter(recent_check__return_code__exact=code, live=True
             ).order_by('provider').annotate(title=F('items__title'))
-        providers = problems.values('provider').distinct().annotate(Count('provider'))
+        providers = problems.values('provider').distinct().annotate(
+            link_count=Count('provider'))
         for provider in providers:
-            provider['links'] = problems.filter(provider=provider['provider'])
-            #provider['count'] = provider['links'].count()
+            provider['links'] = problems.filter(
+                provider=provider['provider'])[:100]
         return {'code': code, 'providers': providers}
 
 

--- a/doab_check/views.py
+++ b/doab_check/views.py
@@ -48,7 +48,7 @@ class ProblemsView(generic.TemplateView):
             link_count=Count('provider'))
         for provider in providers:
             provider['links'] = problems.filter(
-                provider=provider['provider'])[:100]
+                provider=provider['provider']).order_by('url')[:100]
         return {'code': code, 'providers': providers}
 
 

--- a/doab_check/views.py
+++ b/doab_check/views.py
@@ -42,6 +42,7 @@ class ProblemsView(generic.TemplateView):
 
         problems = Link.objects.exclude(recent_check__isnull=True
             ).filter(recent_check__return_code__exact=code, live=True
+            ).select_related('recent_check'
             ).order_by('provider').annotate(title=F('items__title'))
         providers = problems.values('provider').distinct().annotate(
             link_count=Count('provider'))


### PR DESCRIPTION
**Fixes #8** — Homepage takes 12 seconds to load, /problems/429/ crashes with 502

## Summary

Two performance fixes for the web views:

### Homepage: 12s → 0.5s
Replaced the per-status-code `COUNT` loop (N+1 queries) with a single `GROUP BY` aggregation:
```python
# Before: ~15 separate COUNT queries
for code in codes:
    code['count'] = active_links.filter(...).count()

# After: 1 query
codes = active_links.values('recent_check__return_code').annotate(count=Count('id'))
```

### Problems view: 502 crash → 200 in 0.2s
`/problems/429/` was crashing with 502 (gunicorn timeout) trying to render all 19,775 links inline. Added a 100-link-per-provider limit with deterministic ordering, plus `select_related` to eliminate template-level lazy queries.

### Verified locally
Tested against full production DB dump (101K items, 4.4M checks) in Docker:

| Page | Before | After |
|------|--------|-------|
| Homepage | 12.0s | 0.5s |
| /problems/429/ | 502 crash | 0.2s |
| /problems/524/ | ~15s | 0.1s |

**Related**: Remaining N+1 optimization and pagination tracked in #10