### PR TITLE
doab_load.sh: pass explicit from_date to sidestep cursor stall (#12)

### DIFF
--- a/scripts/doab_load.sh
+++ b/scripts/doab_load.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 #
+# Nightly DOAB OAI harvest.
+#
+# Passing an explicit `from_date` (3 days back, rolling window) routes
+# through the if-from_date branch in load_doab_oai. The no-from_date path
+# stalls on pyoai's resumption-token follow-up and freezes the cursor —
+# see EbookFoundation/doab-check#12. load_doab dedupes by record id, so
+# the 3-day overlap is cheap and resilient to occasional missed nights.
+#
+# Captures stderr too so sentinel-write failures from the Retry-After
+# logic (#14) are visible in the cron log, not lost to root mail.
 
-cd /home/ubuntu/doab-check
-/home/ubuntu/.local/bin/pipenv run python manage.py load_doab >> logs/cron_load.log
+cd /home/ubuntu/doab-check || exit 1
+/home/ubuntu/.local/bin/pipenv run python manage.py load_doab \
+    "$(date -u -d '3 days ago' +%Y-%m-%d)" --max=20000 \
+    >> logs/cron_load.log 2>&1


### PR DESCRIPTION
Sidesteps the cursor stall documented in EbookFoundation/doab-check#12 by passing an explicit 3-day from_date (matching the regluit cron pattern from regluit-provisioning#31).

Also captures stderr to the cron log, so sentinel-write failures from #14 (Retry-After respect, merged today) are visible.

Doesn't fix the underlying pyoai cursor-stall bug — just routes around it the same way regluit does.

`load_doab` dedupes by record id, so the 3-day overlap is cheap and resilient to occasional missed nights.

Codex-reviewed (no blockers; `cd ... || exit 1` hardening applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)