### PR TITLE
Pin lxml < 5 for pyoai compatibility

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,10 @@ name = "pypi"
 [packages]
 django = "*"
 psycopg2 = "*"
+# pyoai (and our EbookFoundation/pyoai fork) calls
+# XPathElementEvaluator.evaluate(), removed in lxml 5+. Pin lxml until
+# pyoai upstream is patched (see infrae/pyoai#59).
+lxml = "<5"
 pyoai = {editable = true, ref = "bf709d26ae6e4b34b9b0ca726e0f032d97f0bd38", git = "git+https://github.com/EbookFoundation/pyoai.git"}
 requests = "*"
 gunicorn = "*"


### PR DESCRIPTION
pyoai (both stock infrae/pyoai 2.5.1 and our fork) calls `XPathElementEvaluator.evaluate()` which was removed in lxml 5. Unpinned `lxml = "*"` now resolves to lxml 6.1+. Need an explicit constraint.

Caught during today's deploy of #16: routine `pipenv install` resolved lxml 6.1.0 → `AttributeError` on harvest. Recovered by restoring an older Pipfile.lock; this PR makes the constraint explicit so future `pipenv install` runs are safe.

Upstream: [infrae/pyoai#59](https://github.com/infrae/pyoai/issues/59)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
