### PR TITLE
Add backfill_doab management command (refs #18)

### DIFF
--- a/doab_check/management/commands/backfill_doab.py
+++ b/doab_check/management/commands/backfill_doab.py
@@ -343,6 +343,7 @@ class Command(BaseCommand):
                 # 7c. Remote fetch (DB-free)
                 remote_calls += 1
                 record = None
+                stop_after_this_record = False  # set True on 429-recovered path
                 try:
                     record = get_doab_record_safe(doab_id)
                 except _PyOAIRateLimitedError as e:
@@ -350,9 +351,14 @@ class Command(BaseCommand):
                         e, doab_id, state, opt['max_retry_after']
                     )
                     if exit_reason == 'recovered':
+                        # Slept the Retry-After, attempt one final fetch, then
+                        # exit regardless of outcome — DOAB asked us to slow
+                        # down; we honor the wait but don't keep probing.
                         try:
                             record = get_doab_record_safe(doab_id)
                             remote_calls += 1
+                            exit_reason = '429_recovered_single_record'
+                            stop_after_this_record = True
                         except Exception:
                             mark_retry(state, doab_id, '429_after_wait')
                             recompute_totals(state)
@@ -407,14 +413,24 @@ class Command(BaseCommand):
                     processed_in_run += 1
                     recompute_totals(state)
                     save_state(opt['state_file'], state)
+                    if stop_after_this_record:
+                        break
                     continue
 
-                # 7e. Local DB write — narrowly scoped transaction
+                # OAI says deleted (header status=deleted) or no metadata —
+                # treat as gone directly. add_by_doab() would otherwise call
+                # set_deleted() which returns None when the local Item
+                # doesn't exist, and we'd lose this signal as error_review.
+                record_is_deleted = record[0].isDeleted() or not record[1]
+
+                # 7e. Local DB write. add_by_doab() handles record[0].isDeleted()
+                # via set_deleted() internally and may make HTTP calls along the
+                # way; transaction.atomic() therefore *does* hold a DB tx during
+                # those HTTP calls. We accept the trade-off: per-record
+                # atomicity > the in-transaction HTTP cost; add_by_doab is
+                # idempotent so a partial-state retry is safe.
                 try:
                     with transaction.atomic():
-                        # add_by_doab also handles record[0].isDeleted() via
-                        # set_deleted(); accept either Item (added or marked
-                        # deleted) as a valid outcome.
                         item = doab_oai.add_by_doab(doab_id, record=record)
                 except IntegrityError:
                     if Item.objects.filter(doab=doab_id, status=1).exists():
@@ -423,6 +439,8 @@ class Command(BaseCommand):
                         processed_in_run += 1
                         recompute_totals(state)
                         save_state(opt['state_file'], state)
+                        if stop_after_this_record:
+                            break
                         continue
                     logger.exception('IntegrityError but ID still absent: %s', doab_id)
                     unknown_errors += 1
@@ -439,6 +457,8 @@ class Command(BaseCommand):
                     processed_in_run += 1
                     recompute_totals(state)
                     save_state(opt['state_file'], state)
+                    if stop_after_this_record:
+                        break
                     continue
                 except Exception as e:
                     logger.exception('Unknown exception loading %s', doab_id)
@@ -449,21 +469,48 @@ class Command(BaseCommand):
                     exit_reason = 'unknown_exception_halt'
                     break
 
-                # 7f. Categorize write result
-                if item is None:
-                    mark_terminal(state, doab_id, 'error_review',
-                                  last_error='add_by_doab returned None')
-                elif getattr(item, 'status', 1) == 0:
-                    # Record came back and was set_deleted — count as gone, not ok
+                # 7f. Categorize write result.
+                #
+                # Four cases based on (record.isDeleted, item, item.status):
+                #
+                # 1. record deleted, item is None
+                #    → DOAB says deleted AND we never had it. set_deleted()
+                #      logged 'no item' and returned None. Mark 'gone'.
+                # 2. record deleted, item is not None
+                #    → DOAB says deleted, we had it (status now 0 from
+                #      set_deleted). Mark 'gone'.
+                # 3. record active, item is None
+                #    → load_doab_record returned None for an active record —
+                #      genuine loader anomaly. error_review.
+                # 4. record active, item.status == 0
+                #    → BUG in load_doab_record: get_or_create found existing
+                #      row with status=0 from a prior delete and never reset
+                #      it to 1. Patch here in backfill: flip status=1, mark
+                #      'ok'. (Loader fix is a separate concern.)
+                # 5. record active, item.status == 1
+                #    → normal happy path. Mark 'ok'.
+                if record_is_deleted:
                     mark_terminal(state, doab_id, 'gone',
-                                  note='set_deleted_after_fetch')
+                                  note='oai_marked_deleted')
                     gone_in_run += 1
+                elif item is None:
+                    mark_terminal(state, doab_id, 'error_review',
+                                  last_error='add_by_doab returned None for active record')
+                elif getattr(item, 'status', 1) == 0:
+                    # Active in DOAB but locally still status=0 — fix it here.
+                    item.status = 1
+                    item.save(update_fields=['status'])
+                    mark_terminal(state, doab_id, 'ok',
+                                  item_id=getattr(item, 'id', None),
+                                  note='status_flipped_0_to_1')
                 else:
                     mark_terminal(state, doab_id, 'ok',
                                   item_id=getattr(item, 'id', None))
                 processed_in_run += 1
                 recompute_totals(state)
                 save_state(opt['state_file'], state)
+                if stop_after_this_record:
+                    break
         finally:
             state['last_run'] = {
                 'started_at': run_started,

--- a/doab_check/management/commands/backfill_doab.py
+++ b/doab_check/management/commands/backfill_doab.py
@@ -371,19 +371,26 @@ class Command(BaseCommand):
                         break
                 except urllib.error.HTTPError as e:
                     if e.code == 429:
+                        # Stock-pyoai fallback path. The patched
+                        # EbookFoundation/pyoai fork (pinned in Pipfile)
+                        # raises _PyOAIRateLimitedError instead, handled
+                        # above with the courtesy retry. If we're here, we're
+                        # running against an unpatched pyoai — be conservative:
+                        # write the shared sentinel and exit cleanly, no
+                        # retry. The next run will honor the sentinel.
                         retry_after = e.headers.get('Retry-After') if e.headers else None
                         try:
-                            secs = int(retry_after) if retry_after else None
+                            secs = int(retry_after) if retry_after else DEFAULT_RETRY_AFTER_SECS
                         except (TypeError, ValueError):
-                            secs = None
-                        pseudo = _PyOAIRateLimitedError()
-                        pseudo.retry_after_seconds = secs
-                        pseudo.retry_after_raw = retry_after
-                        exit_reason = self._handle_rate_limit(
-                            pseudo, doab_id, state, opt['max_retry_after']
-                        )
+                            secs = DEFAULT_RETRY_AFTER_SECS
+                        deadline = _now_utc() + datetime.timedelta(seconds=secs)
+                        write_block_deadline(deadline, stderr=self.stderr)
+                        mark_retry(state, doab_id,
+                                   f'HTTPError 429 (stock pyoai fallback); '
+                                   f'Retry-After={secs}s')
                         recompute_totals(state)
                         save_state(opt['state_file'], state)
+                        exit_reason = 'stock_pyoai_429_fallback'
                         break
                     if 500 <= e.code < 600:
                         mark_retry(state, doab_id, f'HTTPError {e.code}')

--- a/doab_check/management/commands/backfill_doab.py
+++ b/doab_check/management/commands/backfill_doab.py
@@ -56,6 +56,19 @@ logger = logging.getLogger(__name__)
 TERMINAL = ('ok', 'gone', 'present_locally', 'error_review')
 # Non-terminal: 'retry' (re-attempt next run); absent = not yet attempted
 
+# Process exit codes — consumed by the orchestration runner so it can tell
+# "done" from "safe to re-invoke next tick" from "stop, a human must look".
+#   0  drained / nothing-to-do  -> runner writes .done
+#   3  benign checkpoint (rate-limit, max-remote-calls, transient) -> re-fire
+#   4  circuit-breaker halt (error/gone rate, unknown) -> runner freezes
+EXIT_OK = 0
+EXIT_CHECKPOINT = 3
+EXIT_HALT = 4
+HALT_REASONS = frozenset({
+    'error_rate_halt', 'gone_rate_halt',
+    'unknown_http_error_halt', 'unknown_exception_halt',
+})
+
 DEFAULT_RETRY_AFTER_SECS = 60
 
 
@@ -324,7 +337,7 @@ class Command(BaseCommand):
                 f"SKIP: DOAB OAI rate-limited until {deadline.isoformat()} "
                 f"(shared sentinel). Use --ignore-retry-after to override."
             )
-            return
+            sys.exit(EXIT_CHECKPOINT)
         if deadline and now >= deadline:
             live = clear_sentinel()
             if live and not opt['ignore_retry_after']:
@@ -332,7 +345,7 @@ class Command(BaseCommand):
                     f"SKIP: DOAB OAI rate-limited until {live.isoformat()} "
                     f"(concurrent writer; shared sentinel)."
                 )
-                return
+                sys.exit(EXIT_CHECKPOINT)
 
         # --- 7. Per-record loop -----------------------------------------------
         run_started = _now_iso()
@@ -587,8 +600,9 @@ class Command(BaseCommand):
             f"pct_complete={pct:.1f}% "
             f"remote_calls_this_run={remote_calls}"
         )
-        if exit_reason != 'drained':
-            sys.exit(1)
+        if exit_reason == 'drained':
+            return  # EXIT_OK — worklist fully terminal; runner writes .done
+        sys.exit(EXIT_HALT if exit_reason in HALT_REASONS else EXIT_CHECKPOINT)
 
     # --- helpers -------------------------------------------------------------
 

--- a/doab_check/management/commands/backfill_doab.py
+++ b/doab_check/management/commands/backfill_doab.py
@@ -18,6 +18,7 @@ graph, just Item + Link rows from oai_dc metadata.
 
 import argparse
 import datetime
+import email.utils
 import hashlib
 import json
 import logging
@@ -56,6 +57,32 @@ TERMINAL = ('ok', 'gone', 'present_locally', 'error_review')
 # Non-terminal: 'retry' (re-attempt next run); absent = not yet attempted
 
 DEFAULT_RETRY_AFTER_SECS = 60
+
+
+def parse_retry_after(raw):
+    """Parse a Retry-After header per RFC 9110 §10.2.3 — delta-seconds OR an
+    HTTP-date. Returns int seconds (>= 0) or None. doab-check has no shared
+    parser (the pyoai fork pre-parses retry_after_seconds for the fork path);
+    this exists so the stock-pyoai HTTPError fallback does not collapse a
+    multi-hour date ban to DEFAULT_RETRY_AFTER_SECS via a bare int()."""
+    if not raw:
+        return None
+    raw = raw.strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        pass
+    try:
+        target = email.utils.parsedate_to_datetime(raw)
+    except (TypeError, ValueError):
+        return None
+    if target is None:
+        return None
+    if target.tzinfo is None:
+        target = target.replace(tzinfo=datetime.timezone.utc)
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return max(0, int((target - now).total_seconds()))
+
 
 # Accepts: '20.500.12854/N', 'N.M' suffix versions, or prefixed forms
 ID_RE = re.compile(r'^(?:oai:(?:directory\.doabooks\.org|doab-books):)?'
@@ -299,7 +326,13 @@ class Command(BaseCommand):
             )
             return
         if deadline and now >= deadline:
-            clear_sentinel()
+            live = clear_sentinel()
+            if live and not opt['ignore_retry_after']:
+                self.stdout.write(
+                    f"SKIP: DOAB OAI rate-limited until {live.isoformat()} "
+                    f"(concurrent writer; shared sentinel)."
+                )
+                return
 
         # --- 7. Per-record loop -----------------------------------------------
         run_started = _now_iso()
@@ -359,8 +392,15 @@ class Command(BaseCommand):
                             remote_calls += 1
                             exit_reason = '429_recovered_single_record'
                             stop_after_this_record = True
-                        except Exception:
-                            mark_retry(state, doab_id, '429_after_wait')
+                        except Exception as e2:
+                            # The courtesy retry itself failed. If it is another
+                            # rate-limit, DOAB may now want a LONGER wait than
+                            # the first Retry-After — extend the shared sentinel
+                            # (monotonic) so the next run honors the new ban
+                            # instead of re-hitting a still-banned endpoint.
+                            self._extend_sentinel_from_exc(e2)
+                            mark_retry(state, doab_id,
+                                       f'429_after_wait: {type(e2).__name__}')
                             recompute_totals(state)
                             save_state(opt['state_file'], state)
                             exit_reason = '429_after_wait_still_failing'
@@ -379,10 +419,10 @@ class Command(BaseCommand):
                         # write the shared sentinel and exit cleanly, no
                         # retry. The next run will honor the sentinel.
                         retry_after = e.headers.get('Retry-After') if e.headers else None
-                        try:
-                            secs = int(retry_after) if retry_after else DEFAULT_RETRY_AFTER_SECS
-                        except (TypeError, ValueError):
-                            secs = DEFAULT_RETRY_AFTER_SECS
+                        # RFC 9110 §10.2.3: delta-seconds OR HTTP-date. Bare
+                        # int() collapses a multi-hour date ban to
+                        # DEFAULT_RETRY_AFTER_SECS.
+                        secs = parse_retry_after(retry_after) or DEFAULT_RETRY_AFTER_SECS
                         deadline = _now_utc() + datetime.timedelta(seconds=secs)
                         write_block_deadline(deadline, stderr=self.stderr)
                         mark_retry(state, doab_id,
@@ -430,12 +470,15 @@ class Command(BaseCommand):
                 # doesn't exist, and we'd lose this signal as error_review.
                 record_is_deleted = record[0].isDeleted() or not record[1]
 
-                # 7e. Local DB write. add_by_doab() handles record[0].isDeleted()
-                # via set_deleted() internally and may make HTTP calls along the
-                # way; transaction.atomic() therefore *does* hold a DB tx during
-                # those HTTP calls. We accept the trade-off: per-record
-                # atomicity > the in-transaction HTTP cost; add_by_doab is
-                # idempotent so a partial-state retry is safe.
+                # 7e. Local DB write, wrapped in transaction.atomic(). Unlike
+                # regluit's loader, doab-check's add_by_doab -> load_doab_record
+                # is PURE DB: get_or_create on Item/Timestamp/Link with no HTTP
+                # (link-liveness is a separate check_items process). So the
+                # transaction is held for milliseconds across the multi-table
+                # write only — atomicity here is cheap and correct (Item +
+                # Timestamps + Links commit together or not at all). It also
+                # handles record[0].isDeleted() via set_deleted() internally.
+                # add_by_doab is idempotent so a partial-state retry is safe.
                 try:
                     with transaction.atomic():
                         item = doab_oai.add_by_doab(doab_id, record=record)
@@ -548,6 +591,24 @@ class Command(BaseCommand):
             sys.exit(1)
 
     # --- helpers -------------------------------------------------------------
+
+    def _extend_sentinel_from_exc(self, exc):
+        """Persist a Retry-After carried by exc (fork RateLimitedError or
+        stock HTTPError 429). write_block_deadline is monotonic, so this only
+        ever lengthens an active ban, never shortens it. Non-rate-limit
+        exceptions fall back to DEFAULT_RETRY_AFTER_SECS so a failed courtesy
+        retry still imposes a brief cool-off rather than zero."""
+        secs = None
+        if isinstance(exc, _PyOAIRateLimitedError):
+            secs = getattr(exc, 'retry_after_seconds', None)
+        elif isinstance(exc, urllib.error.HTTPError) and exc.code == 429:
+            raw = exc.headers.get('Retry-After') if exc.headers else None
+            secs = parse_retry_after(raw)
+        if not secs:
+            secs = DEFAULT_RETRY_AFTER_SECS
+        write_block_deadline(
+            _now_utc() + datetime.timedelta(seconds=secs), stderr=self.stderr
+        )
 
     def _handle_rate_limit(self, exc, doab_id, state, max_retry_after):
         """Apply Retry-After policy. Returns exit_reason or 'recovered'."""

--- a/doab_check/management/commands/backfill_doab.py
+++ b/doab_check/management/commands/backfill_doab.py
@@ -1,0 +1,537 @@
+"""
+backfill_doab — gentle, resumable, observable DOAB ID-list backfill.
+
+One-off catch-up command for DOAB IDs the nightly `load_doab` cron missed.
+Reads a static list of DOAB IDs (bare form `20.500.12854/N` or prefixed
+`oai:doab-books:20.500.12854/N`), processes them via the existing
+`add_by_doab()` loader with rate-limited, ID-keyed JSON state and a 4-way
+per-record outcome taxonomy.
+
+Design context: EbookFoundation/doab-check#18. Mirrors the design from
+Gluejar/regluit#1151's `backfill_doab` command (codex-reviewed twice). Reuses
+the shared Retry-After sentinel from `load_doab.py` so a 429 hit by either
+command suppresses both for the duration of the ban.
+
+doab-check's per-record load is leaner than regluit's: no Author/Work/Edition
+graph, just Item + Link rows from oai_dc metadata.
+"""
+
+import argparse
+import datetime
+import hashlib
+import json
+import logging
+import os
+import random
+import re
+import sys
+import time
+import traceback
+import urllib.error
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import IntegrityError, transaction
+
+from doab_check import doab_oai
+from doab_check.management.commands.load_doab import (
+    SENTINEL_PATH,
+    _now_utc,
+    clear_sentinel,
+    read_block_deadline,
+    write_block_deadline,
+)
+from doab_check.models import Item
+
+try:
+    from oaipmh.client import RateLimitedError as _PyOAIRateLimitedError
+except ImportError:
+    class _PyOAIRateLimitedError(Exception):
+        retry_after_seconds = None
+        retry_after_raw = None
+
+logger = logging.getLogger(__name__)
+
+# Terminal statuses (won't re-attempt)
+TERMINAL = ('ok', 'gone', 'present_locally', 'error_review')
+# Non-terminal: 'retry' (re-attempt next run); absent = not yet attempted
+
+DEFAULT_RETRY_AFTER_SECS = 60
+
+# Accepts: '20.500.12854/N', 'N.M' suffix versions, or prefixed forms
+ID_RE = re.compile(r'^(?:oai:(?:directory\.doabooks\.org|doab-books):)?'
+                   r'(20\.500\.12854/\d+(?:\.\d+)?)$')
+
+
+# --- ID parsing ---------------------------------------------------------------
+
+def normalize_id(s):
+    """Return the canonical doab-check storage form `oai:doab-books:<bare>`,
+    or None if malformed."""
+    s = s.strip()
+    if not s or s.startswith('#'):
+        return None
+    m = ID_RE.match(s)
+    if not m:
+        return None
+    return f'oai:doab-books:{m.group(1)}'
+
+
+def numeric_suffix(doab_id):
+    """Parse the integer suffix after `20.500.12854/` for sorting."""
+    m = re.search(r'20\.500\.12854/(\d+)', doab_id)
+    return int(m.group(1)) if m else -1
+
+
+def load_input_ids(path):
+    """Read + dedupe + validate. Returns (ids_list, sha256, malformed_lines).
+    Output IDs are in canonical `oai:doab-books:<bare>` form."""
+    h = hashlib.sha256()
+    seen = set()
+    ids = []
+    malformed = []
+    with open(path, 'rb') as f:
+        raw_bytes = f.read()
+    h.update(raw_bytes)
+    for lineno, raw in enumerate(raw_bytes.decode('utf-8').splitlines(), start=1):
+        s = raw.strip()
+        if not s or s.startswith('#'):
+            continue
+        canonical = normalize_id(s)
+        if canonical is None:
+            malformed.append((lineno, raw))
+            continue
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        ids.append(canonical)
+    return ids, h.hexdigest(), malformed
+
+
+# --- State management ---------------------------------------------------------
+
+def load_state(path):
+    if not os.path.exists(path):
+        return None
+    with open(path) as f:
+        return json.load(f)
+
+
+def save_state(path, state):
+    """Atomic write via tmp + os.replace so a crash never leaves partial JSON."""
+    tmp = f"{path}.tmp.{os.getpid()}"
+    with open(tmp, 'w') as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+    os.replace(tmp, path)
+
+
+def recompute_totals(state):
+    """Recompute totals from the ids dict — single source of truth, no drift."""
+    counts = {s: 0 for s in TERMINAL + ('retry',)}
+    for entry in state['ids'].values():
+        st = entry.get('status')
+        if st in counts:
+            counts[st] += 1
+    counts['remaining'] = state['ids_file_count'] - sum(
+        counts[s] for s in TERMINAL
+    )
+    state['totals'] = counts
+
+
+def init_state(ids_file_path, ids_count, ids_sha256):
+    return {
+        'started_at': _now_utc().isoformat(),
+        'ids_file_path': ids_file_path,
+        'ids_file_sha256': ids_sha256,
+        'ids_file_count': ids_count,
+        'ids': {},
+        'totals': dict(
+            {s: 0 for s in TERMINAL + ('retry',)},
+            remaining=ids_count,
+        ),
+        'last_run': None,
+    }
+
+
+# --- Per-record outcomes ------------------------------------------------------
+
+def _now_iso():
+    return _now_utc().isoformat()
+
+
+def mark_terminal(state, doab_id, status, **extras):
+    entry = state['ids'].get(doab_id, {})
+    entry['status'] = status
+    entry['last_attempt_at'] = _now_iso()
+    entry['attempts'] = entry.get('attempts', 0) + 1
+    entry.update(extras)
+    state['ids'][doab_id] = entry
+
+
+def mark_retry(state, doab_id, last_error):
+    entry = state['ids'].get(doab_id, {})
+    entry['status'] = 'retry'
+    entry['last_attempt_at'] = _now_iso()
+    entry['attempts'] = entry.get('attempts', 0) + 1
+    entry['last_error'] = last_error
+    state['ids'][doab_id] = entry
+
+
+# --- Pacing -------------------------------------------------------------------
+
+def jittered_sleep(rate, jitter):
+    if rate <= 0:
+        return
+    lo = rate * (1 - jitter)
+    hi = rate * (1 + jitter)
+    time.sleep(random.uniform(lo, hi))
+
+
+# --- Remote fetch (DB-free) ---------------------------------------------------
+
+def get_doab_record_safe(doab_id):
+    """Wrapper around doab_client.getRecord that returns None on
+    IdDoesNotExistError (matching the regluit fork's get_doab_record).
+
+    Lets RateLimitedError, HTTPError, network errors propagate to the caller.
+    """
+    from oaipmh.error import IdDoesNotExistError
+    try:
+        return doab_oai.doab_client.getRecord(
+            metadataPrefix='oai_dc',
+            identifier=doab_oai.getdoab(doab_id, new_ns=True),
+        )
+    except IdDoesNotExistError:
+        return None
+
+
+# --- Main command -------------------------------------------------------------
+
+class Command(BaseCommand):
+    help = "Slow, resumable backfill for DOAB IDs missing from the local DB."
+
+    def add_arguments(self, parser):
+        parser.add_argument('--ids-file', required=True,
+                            help='Path to newline-delimited DOAB IDs (bare or prefixed)')
+        parser.add_argument('--state-file', required=True,
+                            help='Path to JSON state file (created if missing)')
+        parser.add_argument('--rate', type=float, default=3.0,
+                            help='Base seconds between requests (default: 3.0)')
+        parser.add_argument('--jitter', type=float, default=0.2,
+                            help='Fractional jitter on sleep (default: 0.2 = +/-20%%)')
+        parser.add_argument('--max-remote-calls', type=int, default=500,
+                            help='Cap on DOAB requests per run (default: 500)')
+        parser.add_argument('--max-retry-after', type=int, default=300,
+                            help='Retry-After (s) above which to checkpoint+exit (default: 300)')
+        parser.add_argument('--error-rate-halt', type=float, default=0.05,
+                            help='Unknown-error rate above which to halt (default: 0.05)')
+        parser.add_argument('--gone-rate-halt', type=float, default=0.30,
+                            help='Gone rate above which to halt for review (default: 0.30)')
+        parser.add_argument('--order', choices=['newest-first', 'oldest-first', 'as-given'],
+                            default='newest-first',
+                            help='Processing order (default: newest-first)')
+        parser.add_argument('--id-range',
+                            help='Optional numeric range filter, e.g. 170000-179999')
+        parser.add_argument('--dry-run', action='store_true',
+                            help='Validate inputs + state; do not call DOAB')
+        parser.add_argument('--ignore-retry-after', action='store_true',
+                            help='Bypass the shared Retry-After sentinel')
+
+    def handle(self, **opt):
+        # --- 1. Load + validate input -----------------------------------------
+        ids, sha256, malformed = load_input_ids(opt['ids_file'])
+        if malformed:
+            self.stderr.write(
+                f"REFUSE: {len(malformed)} malformed line(s) in --ids-file; "
+                f"first: line {malformed[0][0]}: {malformed[0][1]!r}"
+            )
+            raise CommandError("Malformed input file")
+        if not ids:
+            raise CommandError("No valid IDs in --ids-file")
+
+        # --- 2. Load or initialize state --------------------------------------
+        state = load_state(opt['state_file'])
+        if state is not None:
+            if state.get('ids_file_sha256') != sha256:
+                raise CommandError(
+                    f"REFUSE: --ids-file SHA256 changed since state was created. "
+                    f"State expects {state.get('ids_file_sha256')[:12]}..., "
+                    f"file is {sha256[:12]}.... Use a fresh --state-file or "
+                    f"restore the original input."
+                )
+        else:
+            state = init_state(opt['ids_file'], len(ids), sha256)
+
+        # --- 3. Apply --id-range filter ---------------------------------------
+        if opt['id_range']:
+            try:
+                lo_str, hi_str = opt['id_range'].split('-')
+                lo, hi = int(lo_str), int(hi_str)
+            except ValueError:
+                raise CommandError(f"--id-range must be N-M (got {opt['id_range']!r})")
+            ids = [i for i in ids if lo <= numeric_suffix(i) <= hi]
+
+        # --- 4. Order ---------------------------------------------------------
+        if opt['order'] == 'newest-first':
+            ids.sort(key=numeric_suffix, reverse=True)
+        elif opt['order'] == 'oldest-first':
+            ids.sort(key=numeric_suffix)
+
+        # --- 5. Filter out already-terminal -----------------------------------
+        pending = [i for i in ids
+                   if state['ids'].get(i, {}).get('status') not in TERMINAL]
+
+        self.stdout.write(
+            f"[backfill] input={len(ids)} pending={len(pending)} "
+            f"sha256={sha256[:12]}... order={opt['order']}"
+        )
+
+        if opt['dry_run']:
+            self._dry_run_report(ids, pending, state, opt)
+            return
+
+        # --- 6. Honor shared Retry-After sentinel -----------------------------
+        deadline = read_block_deadline()
+        now = _now_utc()
+        if deadline and now < deadline and not opt['ignore_retry_after']:
+            self.stdout.write(
+                f"SKIP: DOAB OAI rate-limited until {deadline.isoformat()} "
+                f"(shared sentinel). Use --ignore-retry-after to override."
+            )
+            return
+        if deadline and now >= deadline:
+            clear_sentinel()
+
+        # --- 7. Per-record loop -----------------------------------------------
+        run_started = _now_iso()
+        remote_calls = 0
+        unknown_errors = 0
+        gone_in_run = 0
+        processed_in_run = 0
+        exit_reason = 'drained'
+
+        try:
+            for doab_id in pending:
+                # Stop conditions checked at top of loop
+                if remote_calls >= opt['max_remote_calls']:
+                    exit_reason = 'max_remote_calls'
+                    break
+                if processed_in_run >= 50 and (
+                    unknown_errors / processed_in_run > opt['error_rate_halt']
+                ):
+                    exit_reason = 'error_rate_halt'
+                    break
+                if processed_in_run >= 100 and (
+                    gone_in_run / processed_in_run > opt['gone_rate_halt']
+                ):
+                    exit_reason = 'gone_rate_halt'
+                    break
+
+                # 7a. Local precheck (no DOAB call, no sleep). doab-check stores
+                # IDs in canonical 'oai:doab-books:<bare>' form (which is what
+                # normalize_id returned).
+                if Item.objects.filter(doab=doab_id, status=1).exists():
+                    mark_terminal(state, doab_id, 'present_locally',
+                                  checked_at=_now_iso())
+                    recompute_totals(state)
+                    save_state(opt['state_file'], state)
+                    processed_in_run += 1
+                    continue
+
+                # 7b. Pacing — before remote call
+                jittered_sleep(opt['rate'], opt['jitter'])
+
+                # 7c. Remote fetch (DB-free)
+                remote_calls += 1
+                record = None
+                try:
+                    record = get_doab_record_safe(doab_id)
+                except _PyOAIRateLimitedError as e:
+                    exit_reason = self._handle_rate_limit(
+                        e, doab_id, state, opt['max_retry_after']
+                    )
+                    if exit_reason == 'recovered':
+                        try:
+                            record = get_doab_record_safe(doab_id)
+                            remote_calls += 1
+                        except Exception:
+                            mark_retry(state, doab_id, '429_after_wait')
+                            recompute_totals(state)
+                            save_state(opt['state_file'], state)
+                            exit_reason = '429_after_wait_still_failing'
+                            break
+                    else:
+                        recompute_totals(state)
+                        save_state(opt['state_file'], state)
+                        break
+                except urllib.error.HTTPError as e:
+                    if e.code == 429:
+                        retry_after = e.headers.get('Retry-After') if e.headers else None
+                        try:
+                            secs = int(retry_after) if retry_after else None
+                        except (TypeError, ValueError):
+                            secs = None
+                        pseudo = _PyOAIRateLimitedError()
+                        pseudo.retry_after_seconds = secs
+                        pseudo.retry_after_raw = retry_after
+                        exit_reason = self._handle_rate_limit(
+                            pseudo, doab_id, state, opt['max_retry_after']
+                        )
+                        recompute_totals(state)
+                        save_state(opt['state_file'], state)
+                        break
+                    if 500 <= e.code < 600:
+                        mark_retry(state, doab_id, f'HTTPError {e.code}')
+                        recompute_totals(state)
+                        save_state(opt['state_file'], state)
+                        exit_reason = 'transient_failure'
+                        break
+                    logger.exception('Unexpected HTTPError %s for %s', e.code, doab_id)
+                    mark_terminal(state, doab_id, 'error_review',
+                                  last_error=f'HTTPError {e.code}')
+                    recompute_totals(state)
+                    save_state(opt['state_file'], state)
+                    exit_reason = 'unknown_http_error_halt'
+                    break
+                except (urllib.error.URLError, TimeoutError, ConnectionError) as e:
+                    mark_retry(state, doab_id, f'{type(e).__name__}: {e}')
+                    recompute_totals(state)
+                    save_state(opt['state_file'], state)
+                    exit_reason = 'network_failure'
+                    break
+
+                # 7d. Categorize fetch result
+                if record is None:
+                    # IdDoesNotExistError swallowed by get_doab_record_safe
+                    mark_terminal(state, doab_id, 'gone')
+                    gone_in_run += 1
+                    processed_in_run += 1
+                    recompute_totals(state)
+                    save_state(opt['state_file'], state)
+                    continue
+
+                # 7e. Local DB write — narrowly scoped transaction
+                try:
+                    with transaction.atomic():
+                        # add_by_doab also handles record[0].isDeleted() via
+                        # set_deleted(); accept either Item (added or marked
+                        # deleted) as a valid outcome.
+                        item = doab_oai.add_by_doab(doab_id, record=record)
+                except IntegrityError:
+                    if Item.objects.filter(doab=doab_id, status=1).exists():
+                        mark_terminal(state, doab_id, 'present_locally',
+                                      note='race_resolved')
+                        processed_in_run += 1
+                        recompute_totals(state)
+                        save_state(opt['state_file'], state)
+                        continue
+                    logger.exception('IntegrityError but ID still absent: %s', doab_id)
+                    unknown_errors += 1
+                    mark_terminal(state, doab_id, 'error_review',
+                                  last_error='IntegrityError')
+                    recompute_totals(state)
+                    save_state(opt['state_file'], state)
+                    exit_reason = 'unknown_exception_halt'
+                    break
+                except (ValueError, TypeError) as e:
+                    logger.warning('Validation error loading %s: %s', doab_id, e)
+                    mark_terminal(state, doab_id, 'error_review',
+                                  last_error=f'{type(e).__name__}: {e}')
+                    processed_in_run += 1
+                    recompute_totals(state)
+                    save_state(opt['state_file'], state)
+                    continue
+                except Exception as e:
+                    logger.exception('Unknown exception loading %s', doab_id)
+                    mark_retry(state, doab_id, f'{type(e).__name__}: {e}')
+                    unknown_errors += 1
+                    recompute_totals(state)
+                    save_state(opt['state_file'], state)
+                    exit_reason = 'unknown_exception_halt'
+                    break
+
+                # 7f. Categorize write result
+                if item is None:
+                    mark_terminal(state, doab_id, 'error_review',
+                                  last_error='add_by_doab returned None')
+                elif getattr(item, 'status', 1) == 0:
+                    # Record came back and was set_deleted — count as gone, not ok
+                    mark_terminal(state, doab_id, 'gone',
+                                  note='set_deleted_after_fetch')
+                    gone_in_run += 1
+                else:
+                    mark_terminal(state, doab_id, 'ok',
+                                  item_id=getattr(item, 'id', None))
+                processed_in_run += 1
+                recompute_totals(state)
+                save_state(opt['state_file'], state)
+        finally:
+            state['last_run'] = {
+                'started_at': run_started,
+                'finished_at': _now_iso(),
+                'exit_reason': exit_reason,
+                'remote_calls': remote_calls,
+                'processed': processed_in_run,
+                'unknown_errors': unknown_errors,
+                'gone_in_run': gone_in_run,
+            }
+            recompute_totals(state)
+            save_state(opt['state_file'], state)
+
+        terminal_count = sum(state['totals'][s] for s in TERMINAL)
+        pct = (100.0 * terminal_count / state['ids_file_count']
+               if state['ids_file_count'] else 0)
+        self.stdout.write(
+            f"[backfill] run done: ok={state['totals']['ok']} "
+            f"gone={state['totals']['gone']} "
+            f"present_locally={state['totals']['present_locally']} "
+            f"retry={state['totals']['retry']} "
+            f"error_review={state['totals']['error_review']} "
+            f"exit={exit_reason} "
+            f"pct_complete={pct:.1f}% "
+            f"remote_calls_this_run={remote_calls}"
+        )
+        if exit_reason != 'drained':
+            sys.exit(1)
+
+    # --- helpers -------------------------------------------------------------
+
+    def _handle_rate_limit(self, exc, doab_id, state, max_retry_after):
+        """Apply Retry-After policy. Returns exit_reason or 'recovered'."""
+        secs = exc.retry_after_seconds or DEFAULT_RETRY_AFTER_SECS
+        deadline = _now_utc() + datetime.timedelta(seconds=secs)
+        write_block_deadline(deadline, stderr=self.stderr)
+        if secs <= max_retry_after:
+            self.stdout.write(
+                f"[backfill] 429 on {doab_id}; sleeping {secs}s then single retry"
+            )
+            time.sleep(secs)
+            return 'recovered'
+        else:
+            mark_retry(state, doab_id, f'Retry-After={secs}s exceeds cap={max_retry_after}s')
+            self.stdout.write(
+                f"[backfill] 429 on {doab_id}; Retry-After={secs}s > cap "
+                f"{max_retry_after}s; checkpoint + exit (sentinel set to "
+                f"{deadline.isoformat()})"
+            )
+            return 'retry_after_too_long'
+
+    def _dry_run_report(self, ids, pending, state, opt):
+        first10 = pending[:10]
+        last10 = pending[-10:]
+        present_preview = Item.objects.filter(
+            doab__in=pending[:1000], status=1
+        ).count()
+        terminal_count = sum(state['totals'][s] for s in TERMINAL)
+        self.stdout.write("=== DRY RUN ===")
+        self.stdout.write(f"  total input IDs:      {len(ids)}")
+        self.stdout.write(f"  already terminal:     {terminal_count}")
+        self.stdout.write(f"  pending this run:     {len(pending)}")
+        self.stdout.write(f"  precheck preview*:    {present_preview} of first 1000 pending already in local DB")
+        self.stdout.write(f"  order:                {opt['order']}")
+        self.stdout.write(f"  range filter:         {opt['id_range'] or 'none'}")
+        self.stdout.write(f"  rate:                 {opt['rate']}s ± {opt['jitter']*100:.0f}%")
+        self.stdout.write(f"  max-remote-calls:     {opt['max_remote_calls']}")
+        self.stdout.write(f"  max-retry-after:      {opt['max_retry_after']}s")
+        self.stdout.write(f"  first 10 to process:  {first10}")
+        self.stdout.write(f"  last 10 to process:   {last10}")
+        self.stdout.write("  (* preview excludes IDs already terminal in state)")

--- a/doab_check/management/commands/load_doab.py
+++ b/doab_check/management/commands/load_doab.py
@@ -52,6 +52,13 @@ def write_block_deadline(deadline, path=SENTINEL_PATH, stderr=None):
     Silent failures here would mask permission/path bugs and reintroduce the
     ban-extension loop this whole patch exists to prevent.
     """
+    # Monotonic: never shorten an active ban. cron and backfill co-own this
+    # file; without this, a short 429 racing a long one (or a stale writer)
+    # could replace a longer deadline with a shorter one and let us hit a
+    # still-banned endpoint early. Only ever move the deadline later.
+    existing = read_block_deadline(path)
+    if existing is not None and existing >= deadline:
+        return True
     try:
         with open(path, 'w') as f:
             f.write(deadline.isoformat())
@@ -66,10 +73,23 @@ def write_block_deadline(deadline, path=SENTINEL_PATH, stderr=None):
 
 
 def clear_sentinel(path=SENTINEL_PATH):
-    try:
-        os.remove(path)
-    except OSError:
-        pass
+    """Intentionally NEVER deletes the sentinel file.
+
+    An expired deadline is already harmless: every caller compares it to
+    `now` and proceeds, and the next 429 overwrites it (write is monotonic).
+    Deleting introduces an unavoidable read-then-remove TOCTOU — a fresh
+    future deadline written by another process (cron vs backfill) between the
+    read and os.remove() would be erased, dropping an active DOAB ban. Not
+    deleting eliminates that race entirely; the file is a single tiny value
+    that is overwritten, never appended.
+
+    Returns the still-active deadline if one is present (caller must honor
+    it); returns None if absent or expired (caller may proceed).
+    """
+    deadline = read_block_deadline(path)
+    if deadline is not None and _now_utc() < deadline:
+        return deadline  # still-active ban — caller must honor it
+    return None
 
 
 class Command(BaseCommand):
@@ -98,7 +118,13 @@ class Command(BaseCommand):
             )
             return
         if deadline and now >= deadline:
-            clear_sentinel()
+            live = clear_sentinel()
+            if live and not ignore:
+                self.stdout.write(
+                    'SKIP: DOAB OAI rate-limited until {} (concurrent writer; '
+                    'honoring Retry-After).'.format(live.isoformat())
+                )
+                return
 
         self.stdout.write('starting at date:{} until:{}, max: {}'.format(
                           from_date, until_date, max))

--- a/scripts/doab-backfill.sh
+++ b/scripts/doab-backfill.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# DOAB backfill runner for doab-check (EbookFoundation/doab-check#18).
+#
+# doab-check runs on a single DigitalOcean droplet under pipenv (NOT Ansible),
+# so this is a static, env-configurable script rather than a templated one.
+# It mirrors the regluit runner's contract exactly.
+#
+# One bounded `backfill_doab` pass per cron tick, drained over days, never
+# concurrent with the nightly load_doab harvest (shared host flock), halt
+# circuit-breaker honored ACROSS ticks via .done/.halted markers.
+#
+# doab-check's backfill_doab REQUIRES --ids-file (no discovery): supply the
+# worklist produced by the doab-check#18 audit via IDS_FILE.
+#
+# !! CROSS-HOST SLOW-AND-GENTLE INVARIANT !!
+# The /var/lock/doab-oai.lock flock is HOST-LOCAL. regluit (AWS) and
+# doab-check (DigitalOcean) are separate hosts hitting the SAME DOAB OAI
+# endpoint, so the lock does NOT serialise them against each other. Only
+# ONE DOAB backfill may be armed at a time across both hosts.
+# This runner is INERT until IDS_FILE is set (it hard-refuses below) — that
+# opt-in IS the serialisation gate. Before arming this:
+#   1. regluit's backfill must be drained (.done present) OR its cron paused
+#   2. then set IDS_FILE in this host's crontab to arm doab-check's drain
+# Do not run both concurrently; "slow" is the desired posture (Eric).
+#
+# Exit-code contract (set by the management command):
+#   0  drained / nothing-to-do  -> write .done, stop
+#   3  benign checkpoint        -> do nothing, cron re-fires
+#   4  circuit-breaker halt      -> write .halted, freeze for operator
+#   *  unexpected               -> fail safe: write .halted
+#
+# Suggested crontab (run as the doab-check service user):
+#   # nightly harvest must ALSO take the lock — wrap it the same way:
+#   30 4 * * *   flock -n /var/lock/doab-oai.lock -c 'cd /path/doab-check && pipenv run python manage.py load_doab "$(date -u -d "3 days ago" +\%Y-\%m-\%d)" >> /var/log/doab-check/doab-harvest.log 2>&1'
+#   # minute offset (15,45) vs regluit's 0,30 as defense-in-depth — but the
+#   # real guarantee is the cross-host invariant above (only one host armed):
+#   15,45 * * * * IDS_FILE=/var/lib/doab-check/backfill/worklist.ids /path/doab-check/scripts/doab-backfill.sh
+#
+# NOTE: deliberately NOT `set -e` — we must inspect the command's rc.
+set -uo pipefail
+
+PROJECT_DIR="${PROJECT_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
+STATE_DIR="${STATE_DIR:-/var/lib/doab-check/backfill}"
+LOG="${LOG:-/var/log/doab-check/doab-backfill.log}"
+LOCK="${LOCK:-/var/lock/doab-oai.lock}"
+IDS_FILE="${IDS_FILE:-}"
+
+DONE="$STATE_DIR/.done"
+HALTED="$STATE_DIR/.halted"
+STATE="$STATE_DIR/state.json"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "$(ts) [doab-backfill] $*" >> "$LOG"; }
+
+mkdir -p "$STATE_DIR" "$(dirname "$LOG")" 2>/dev/null || true
+
+if [ -z "$IDS_FILE" ]; then
+    log "IDS_FILE not set — doab-check backfill_doab requires --ids-file; refusing to run"
+    exit 0
+fi
+if [ ! -f "$IDS_FILE" ]; then
+    log "IDS_FILE $IDS_FILE not found; refusing to run"
+    exit 0
+fi
+if [ -f "$DONE" ]; then
+    log ".done present — worklist drained; nothing to do"
+    exit 0
+fi
+if [ -f "$HALTED" ]; then
+    log ".halted present — circuit broken; awaiting operator review of $STATE"
+    exit 0
+fi
+
+exec 9>"$LOCK" || { log "cannot open lock $LOCK; skipping tick"; exit 0; }
+if ! flock -n 9; then
+    log "DOAB-OAI lock held (harvest or prior backfill running); skipping tick"
+    exit 0
+fi
+
+log "starting bounded backfill pass (ids-file=$IDS_FILE)"
+cd "$PROJECT_DIR" || { log "cd $PROJECT_DIR failed; skipping tick"; exit 0; }
+
+pipenv run python manage.py backfill_doab \
+    --ids-file "$IDS_FILE" --state-file "$STATE" >> "$LOG" 2>&1
+rc=$?
+
+case "$rc" in
+    0)
+        touch "$DONE"
+        log "DRAINED (rc=0) -> wrote .done; backfill complete"
+        ;;
+    3)
+        log "checkpoint (rc=3) -> cron will re-fire next tick"
+        ;;
+    4)
+        touch "$HALTED"
+        log "HALT (rc=4) -> wrote .halted; OPERATOR REVIEW NEEDED ($STATE)"
+        ;;
+    *)
+        touch "$HALTED"
+        log "UNEXPECTED rc=$rc -> wrote .halted (fail-safe); OPERATOR REVIEW NEEDED"
+        ;;
+esac
+
+exit 0

--- a/scripts/doab_load.sh
+++ b/scripts/doab_load.sh
@@ -10,8 +10,26 @@
 #
 # Captures stderr too so sentinel-write failures from the Retry-After
 # logic (#14) are visible in the cron log, not lost to root mail.
+#
+# flock /var/lock/doab-oai.lock: same-host serialization with the
+# backfill runner (scripts/doab-backfill.sh). At most one DOAB-OAI
+# client per host; a tick that finds the lock held simply skips (the
+# 3-day rolling window self-heals on the next clear night). Cross-host
+# coordination with regluit is the operator-managed CROSS-HOST INVARIANT
+# documented in scripts/doab-backfill.sh.
+# Retry-After is independently enforced by load_doab.handle() itself.
+
+LOG=/home/ubuntu/doab-check/logs/cron_load.log
+LOCK=/var/lock/doab-oai.lock
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+
+exec 9>"$LOCK" || { echo "$(ts) [doab_load] cannot open lock $LOCK" >> "$LOG"; exit 0; }
+if ! flock -n 9; then
+    echo "$(ts) [doab_load] DOAB-OAI lock held (backfill running); skipping this run" >> "$LOG"
+    exit 0
+fi
 
 cd /home/ubuntu/doab-check || exit 1
 /home/ubuntu/.local/bin/pipenv run python manage.py load_doab \
     "$(date -u -d '3 days ago' +%Y-%m-%d)" --max=20000 \
-    >> logs/cron_load.log 2>&1
+    >> "$LOG" 2>&1


### PR DESCRIPTION
Closes #18 once drained. Recovers the ~14.5k DOAB records missing from doab-check, measured independently of regluit's gap (per the no-extrapolate posture: per-IP rate-limit histories differ; the two services were measured separately).

## What's in this PR (4 commits, bisectable)

| Commit | What |
|---|---|
| `c9221e2` | `load_doab`: monotonic + never-delete shared Retry-After sentinel (race-free). Mirror of the regluit fix; the two repos' sentinel helpers are kept consistent. |
| `f5a8ff0` | `backfill_doab`: Codex-hardened reliability. **Divergence-aware port** of the Gluejar/regluit work: `transaction.atomic()` is **kept** here because doab-check's `add_by_doab → load_doab_record` is pure DB (get_or_create Item/Timestamp/Link, zero HTTP), so the transaction holds for milliseconds — atomicity is cheap and correct. (regluit removed atomic() because its loader interleaves DB writes with minutes of HTTP per record.) 2nd-429 sentinel extension + RFC-9110 stock-pyoai fallback parser. |
| `8f58b6f` | `backfill_doab`: distinct exit codes `0/3/4` for halt-aware orchestration. Skip/rate-limit paths now `sys.exit(3)` (not return-exit-0) so the runner does not falsely mark `.done` on the first ban. |
| `4f00d80` | `scripts/`: `doab-backfill.sh` (the runner) + `doab_load.sh` patch (wrap the existing nightly harvest in the same `/var/lock/doab-oai.lock` flock — same-host serialization with the new backfill so they never hit DOAB OAI concurrently). |

## Approval status

Code converged through **4 Codex review rounds** + **3 orchestration code-review rounds** (final: LGTM in both tracks).

| Round | Outcome |
|---|---|
| R1 | 5 findings (precheck/partial-load applicability **N/A here** — atomic() is kept; 2nd-429, stock-pyoai parser, sentinel races, namespace guard applicable to regluit only) |
| R2 | 4/5 fixed; sentinel-race partial → fixed via `clear_sentinel()` return-contract |
| R3 | Root TOCTOU eliminated via never-delete `clear_sentinel`; Retry-After:0 → 60s endorsed as deliberate (over-conservative, slow-and-gentle posture) |
| R4 | LGTM (command) |
| Orch R1 | Verified rc-capture, exit-code mapping, marker state machine, flock fd lifetime |
| Orch R2 | Caught omission: existing `scripts/doab_load.sh` had no flock → patched in commit `4f00d80` |
| **Orch R3** | **LGTM** — same-host harvest+backfill collision closed |

### Divergence vs regluit (deliberate)

| Aspect | regluit | doab-check |
|---|---|---|
| `transaction.atomic()` around `add_by_doab` | REMOVED (HTTP-in-loop) | **KEPT** (pure-DB, ms-scale) |
| Discovery (`--ids-file` optional) | YES (auto-crawl + diff) | NO (`--ids-file` required) |
| Precheck regression fix (FIX 1) | applied | N/A (atomic() kept) |
| Namespace-drift guard | applied | N/A (no discovery) |

This is exactly the kind of divergence the no-extrapolate review posture is meant to surface — Codex initially suggested mirroring regluit's atomic() removal here, which would have been wrong.

## Cross-host invariant (read before arming)

The `/var/lock/doab-oai.lock` flock is host-local. regluit (AWS) and doab-check (DigitalOcean) hit the same DOAB endpoint, so the lock does **not** serialise them across hosts. The doab-check runner is **inert by default** — hard-refuses unless the operator sets `IDS_FILE` — so the opt-in IS the cross-host serialisation gate. Operational posture: **regluit drains first (`.done` marker present), then doab-check is armed**. Documented loudly in `scripts/doab-backfill.sh`.

## What's out of scope

- Tests for `backfill_doab` — tracked for follow-up.
- An IDS_FILE-producer for the doab-check#18 worklist — the runner takes a path; producing the path is the operator's first step at arm time.

## Backlinks

- Issue: #18 (coverage gap audit, ~14.5k missing)
- Companion: Gluejar/regluit#1152 (parallel regluit backfill)
- Companion: EbookFoundation/regluit-provisioning (orchestration for regluit)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.7, 1M context) — multi-round Codex CLI adversarial review
